### PR TITLE
Changes to squash and save boot and rootfs images to per-target folders and to use them when burning  an sdcard

### DIFF
--- a/create-sdcardiGOS.sh
+++ b/create-sdcardiGOS.sh
@@ -48,7 +48,7 @@ EXEPATH="$PWD"/"$EXE"
 clear
 
 build=${1}
-PARSEPATH=./build/${build}
+PARSEPATH=./images/${build}
 
 cat << EOM
 
@@ -691,9 +691,9 @@ sync
 sync
 
 build=*
-BOOTFILEPATH="$PARSEPATH/tisdk-debian-${build}-boot.tar.xz"
-ROOTFILEPATH="$PARSEPATH/tisdk-debian-${build}-rootfs.tar.xz"
-ROOTFSPATH="$PARSEPATH/tisdk-debian-${build}-rootfs/*"
+BOOTFILEPATH="$PARSEPATH/tisdk-debian-${build}-boot.squashfs"
+ROOTFILEPATH="$PARSEPATH/tisdk-debian-${build}-rootfs.squashfs"
+# ROOTFSPATH="$PARSEPATH/tisdk-debian-${build}-rootfs/*"
 
 cat << EOM
 ################################################################################
@@ -706,13 +706,15 @@ Copying boot partition
 EOM
 
 
-untar_progress $BOOTFILEPATH $PATH_TO_SDBOOT
+# untar_progress $BOOTFILEPATH $PATH_TO_SDBOOT
+unsquashfs -d $PATH_TO_SDBOOT $BOOTFILEPATH
 echo ""
 
 sync
 
 echo "Copying rootfs System partition"
-rsync -aHAX $ROOTFSPATH $PATH_TO_SDROOTFS
+# rsync -aHAX $ROOTFSPATH $PATH_TO_SDROOTFS
+unsquashfs -d $PATH_TO_SDROOTFS $ROOTFILEPATH
 
 echo ""
 echo ""

--- a/scripts/build_distroiGOS.sh
+++ b/scripts/build_distroiGOS.sh
@@ -28,6 +28,7 @@ function package_and_clean() {
 build=$1
 bsp_version=$2
 
+    mkdir -p ${topdir}/images/${build}
     cd ${topdir}/build/${build}
     rm -rf tisdk-debian-${distro}-${bsp_version}-rootfs
     cp -ra ../fs/ tisdk-debian-${distro}-${bsp_version}-rootfs
@@ -39,8 +40,15 @@ bsp_version=$2
 #    tar --use-compress-program="pigz --best --recursive | pv" -cf tisdk-debian-${distro}-${bsp_version}-rootfs.tar.xz tisdk-debian-${distro}-${bsp_version}-rootfs &>>"${LOG_FILE}"
 #    rm -rf tisdk-debian-${distro}-${bsp_version}-rootfs
 
-    tar --use-compress-program="pigz --best --recursive | pv" -cf tisdk-debian-${distro}-${bsp_version}-boot.tar.xz tisdk-debian-${distro}-${bsp_version}-boot &>>"${LOG_FILE}"
-    rm -rf tisdk-debian-${distro}-${bsp_version}-boot
+# latest changes to save the boot and rootfs inside squashfs files that preserve capabilites and file attrs and allows portability in burning an sdcard 
+    mksquashfs tisdk-debian-${distro}-${bsp_version}-rootfs tisdk-debian-${distro}-${bsp_version}-rootfs.squashfs -comp xz -noappend  &>>"${LOG_FILE}"
+    mv tisdk-debian-${distro}-${bsp_version}-rootfs.squashfs ${topdir}/images/${build}
+
+#   tar --use-compress-program="pigz --best --recursive | pv" -cf tisdk-debian-${distro}-${bsp_version}-boot.tar.xz tisdk-debian-${distro}-${bsp_version}-boot &>>"${LOG_FILE}"
+#   rm -rf tisdk-debian-${distro}-${bsp_version}-boot
+
+    mksquashfs tisdk-debian-${distro}-${bsp_version}-boot tisdk-debian-${distro}-${bsp_version}-boot.squashfs -comp xz -noappend &>>"${LOG_FILE}"
+    mv tisdk-debian-${distro}-${bsp_version}-boot.squashfs ${topdir}/images/${build}
 
     rm -rf bsp_sources
 


### PR DESCRIPTION
Need to move away from rsync of a rootfs directory to the sdcard and instead use mkquashfs save the boot and rootfs files for each TI target build in a "images/bookworm-xxxx-evm" folder that is not cleared when doing a "make clean".  The idea is all the images for different targets can exist in a single sandbox so the user can manually burn SD card using the manual  command at the end of the README.md file.   Also, the AWS cloud nightly build will be build all targets and people can directly download those squashfs files and burn the images manually if needed.