### PR TITLE
Modify default UART console to ttyS0 for J7200 platform

### DIFF
--- a/patches/bookworm-j7200-evm/ti-u-boot/0002-modify-j7200-default-console.patch
+++ b/patches/bookworm-j7200-evm/ti-u-boot/0002-modify-j7200-default-console.patch
@@ -1,0 +1,13 @@
+diff --git a/board/ti/j721e/j721e.env b/board/ti/j721e/j721e.env
+index e7bc76431e6..7c78b3f6653 100644
+--- a/board/ti/j721e/j721e.env
++++ b/board/ti/j721e/j721e.env
+@@ -13,7 +13,7 @@ defined(CONFIG_TARGET_J721E_R5_EVM)
+ #endif
+ 
+ name_kern=Image
+-console=ttyS2,115200n8
++console=ttyS0,115200n8
+ args_all=setenv optargs earlycon=ns16550a,mmio32,0x02800000
+ 	${mtdparts}
+ run_kern=booti ${loadaddr} ${rd_spec} ${fdtaddr}


### PR DESCRIPTION
Modify default UART console from ttyS2 to ttyS0 on J7200 platform

should be applied with the PR https://github.com/psleng/vyos-build/pull/7
