### PR TITLE
Fix for empty uboot partition/directory when doing a partial build

### DIFF
--- a/buildiGOSti2.sh
+++ b/buildiGOSti2.sh
@@ -154,9 +154,11 @@ do
     #generate_rootfs ${distro} ${distro_codename} ${machine} ${bsp_version}
 
     uboot=${topdir}/build/${distro}/tisdk-debian-${distro}-${bsp_version}-boot
-    if [ -d $uboot ]; then
-        echo "I: $0: skipping build_bsp since $uboot present"
+    ubootfile=$uboot/u-boot.img
+    if [ -f $ubootfile ]; then
+        echo "I: $0: skipping build_bsp since $ubootfile present"
     else
+        rm -rf $uboot
         echo "I: $0: running build_bsp ${distro} ${machine} ${bsp_version}"
         build_bsp ${distro} ${machine} ${bsp_version}
     fi


### PR DESCRIPTION
When there is an outage at git.ti.com (happens often), we are left with an empty uboot build directory.  Only a "make clean" will remove this directory.  Prior to this check for existence of u-boot.img binary, the script looks only for existence of that uboot build directory and SKIPS building uboot binaries (even though no longer any git-ti.com outage), so you are left with no uboot files and the system will not boot.  We also remove any empty uboot build directory just in case there are binaries left from a previous build that had errors.