### PR TITLE
Uboot fixes for automating the booting of emmc squash image, Uboot fixes for reading uEnv.txt for 'uenvcmd=...' command.  This was done as part of building a production emmc image

### DIFF
--- a/scripts/build_bsp.sh
+++ b/scripts/build_bsp.sh
@@ -263,8 +263,17 @@ bsp_version=$2
     # PERLE - Patching would between bootloader builds would be more cumbersome. Our target would not need this cluge
     case "$machine" in
         am64xx-evm | j7200-evm)
+        # if not j7200, default to am642evm
+        if [ "$machine" = "j7200-evm" ]; then
+            ENV_PATH="board/ti/j721e"
+            ENV_NAME="j721e"
+        else
+            ENV_PATH="board/ti/am64x"
+            ENV_NAME="am64x"
+        fi
+
         # save original env file to restore later
-        cp board/ti/am64x/am64x.env board/ti/am64x/am64x.env.orig
+        cp ${ENV_PATH}/${ENV_NAME}.env ${ENV_PATH}/${ENV_NAME}.env.orig
 
         echo "Building emmc uboot variant for machine type: ${machine}"
         sed -i \
@@ -273,9 +282,9 @@ bsp_version=$2
                 s//bootpart=0:2/
                 a loadbootenv=fatload mmc ${bootpart} ${loadaddr} ${bootenvfile}
               }' \
-          board/ti/am64x/am64x.env
+          ${ENV_PATH}/${ENV_NAME}.env
         # save a copy of the change so we can compare .orig to .emmc, if debugging
-        cp board/ti/am64x/am64x.env board/ti/am64x/am64x.env.emmc
+        cp ${ENV_PATH}/${ENV_NAME}.env ${ENV_PATH}/${ENV_NAME}.env.emmc
 
         OUTDIR="${topdir}/build/${build}/tisdk-debian-${distro}-${bsp_version}-boot-emmc"
 
@@ -294,7 +303,7 @@ bsp_version=$2
         cp ${UBOOT_DIR}/out/${ARM_A_CORE}/u-boot.img ${OUTDIR}/ &>> ${LOG_FILE}
 
         # restore original env file, if debugging.  Normally, the entire bsp_sources are removed
-        cp board/ti/am64x/am64x.env.orig board/ti/am64x/am64x.env
+        cp ${ENV_PATH}/${ENV_NAME}.env.orig ${ENV_PATH}/${ENV_NAME}.env
         ;;
     esac
 }

--- a/scripts/build_bsp.sh
+++ b/scripts/build_bsp.sh
@@ -229,28 +229,73 @@ function build_uboot() {
 machine=$1
 bsp_version=$2
 
+    echo "Building uboot for machine variant: ${machine}"
+
     uboot_r5_defconfig=($(read_machine_config ${machine} uboot_r5_defconfig ${bsp_version}))
     uboot_r5_defconfig=`echo $uboot_r5_defconfig | tr ',' ' '`
     uboot_acore_defconfig=($(read_machine_config ${machine} uboot_${ARM_A_CORE}_defconfig ${bsp_version}))
     platform=($(read_machine_config ${machine} atf_target_board ${bsp_version}))
 
     cd ${UBOOT_DIR}
+
+    # set output for normal build
+    OUTDIR="${topdir}/build/${build}/tisdk-debian-${distro}-${bsp_version}-boot"
+
     log "> uboot-r5: building .."
     make -j`nproc` ARCH=arm CROSS_COMPILE=arm-none-linux-gnueabihf- ${uboot_r5_defconfig} O=${UBOOT_DIR}/out/r5 &>>"${LOG_FILE}"
     make -j`nproc` ARCH=arm CROSS_COMPILE=arm-none-linux-gnueabihf- O=${UBOOT_DIR}/out/r5 BINMAN_INDIRS=${FW_DIR} &>>"${LOG_FILE}"
-    cp ${UBOOT_DIR}/out/r5/tiboot3*.bin ${topdir}/build/${build}/tisdk-debian-${distro}-${bsp_version}-boot/ &>> ${LOG_FILE}
+    cp ${UBOOT_DIR}/out/r5/tiboot3*.bin ${OUTDIR}/ &>> ${LOG_FILE}
 
     cd ${UBOOT_DIR}
     log "> uboot-${ARM_A_CORE}: building .."
     make -j`nproc` ARCH=arm CROSS_COMPILE=${cross_compile} ${uboot_acore_defconfig} O=${UBOOT_DIR}/out/${ARM_A_CORE} &>>"${LOG_FILE}"
     make -j`nproc` ARCH=arm CROSS_COMPILE=${cross_compile} BL31=${TFA_DIR}/build/k3/${platform}/release/bl31.bin TEE=${OPTEE_DIR}/out/arm-plat-k3/core/tee-pager_v2.bin BINMAN_INDIRS=${FW_DIR} O=${UBOOT_DIR}/out/${ARM_A_CORE} &>>"${LOG_FILE}"
-    cp ${UBOOT_DIR}/out/${ARM_A_CORE}/tispl.bin ${topdir}/build/${build}/tisdk-debian-${distro}-${bsp_version}-boot/ &>> ${LOG_FILE}
-    cp ${UBOOT_DIR}/out/${ARM_A_CORE}/u-boot.img ${topdir}/build/${build}/tisdk-debian-${distro}-${bsp_version}-boot/ &>> ${LOG_FILE}
+    cp ${UBOOT_DIR}/out/${ARM_A_CORE}/tispl.bin ${OUTDIR}/ &>> ${LOG_FILE}
+    cp ${UBOOT_DIR}/out/${ARM_A_CORE}/u-boot.img ${OUTDIR}/ &>> ${LOG_FILE}
 
 	case ${machine} in
 		am62pxx-evm | am62xx-evm | am62xx-lp-evm | am62xxsip-evm)
-			cp ${UBOOT_DIR}/tools/logos/ti_logo_414x97_32bpp.bmp.gz ${topdir}/build/${build}/tisdk-debian-${distro}-${bsp_version}-boot/ &>> ${LOG_FILE}
+			cp ${UBOOT_DIR}/tools/logos/ti_logo_414x97_32bpp.bmp.gz ${OUTDIR}/ &>> ${LOG_FILE}
 			;;
 	esac
+
+    # PERLE - For the 2 evms, we need separate emmc output suffix and modify env file to use mmcdev 0 and fix loadbootenv bug
+    # PERLE - Patching would between bootloader builds would be more cumbersome. Our target would not need this cluge
+    case "$machine" in
+        am64xx-evm | j7200-evm)
+        # save original env file to restore later
+        cp board/ti/am64x/am64x.env board/ti/am64x/am64x.env.orig
+
+        echo "Building emmc uboot variant for machine type: ${machine}"
+        sed -i \
+          -e 's/^mmcdev=1$/mmcdev=0/' \
+          -e '/^bootpart=1:2$/ {
+                s//bootpart=0:2/
+                a loadbootenv=fatload mmc ${bootpart} ${loadaddr} ${bootenvfile}
+              }' \
+          board/ti/am64x/am64x.env
+        # save a copy of the change so we can compare .orig to .emmc, if debugging
+        cp board/ti/am64x/am64x.env board/ti/am64x/am64x.env.emmc
+
+        OUTDIR="${topdir}/build/${build}/tisdk-debian-${distro}-${bsp_version}-boot-emmc"
+
+        mkdir -p ${OUTDIR}
+
+        log "> uboot-r5: building .."
+        make -j`nproc` ARCH=arm CROSS_COMPILE=arm-none-linux-gnueabihf- ${uboot_r5_defconfig} O=${UBOOT_DIR}/out/r5 &>>"${LOG_FILE}"
+        make -j`nproc` ARCH=arm CROSS_COMPILE=arm-none-linux-gnueabihf- O=${UBOOT_DIR}/out/r5 BINMAN_INDIRS=${FW_DIR} &>>"${LOG_FILE}"
+        cp ${UBOOT_DIR}/out/r5/tiboot3*.bin ${OUTDIR}/ &>> ${LOG_FILE}
+
+        cd ${UBOOT_DIR}
+        log "> uboot-${ARM_A_CORE}: building .."
+        make -j`nproc` ARCH=arm CROSS_COMPILE=${cross_compile} ${uboot_acore_defconfig} O=${UBOOT_DIR}/out/${ARM_A_CORE} &>>"${LOG_FILE}"
+        make -j`nproc` ARCH=arm CROSS_COMPILE=${cross_compile} BL31=${TFA_DIR}/build/k3/${platform}/release/bl31.bin TEE=${OPTEE_DIR}/out/arm-plat-k3/core/tee-pager_v2.bin BINMAN_INDIRS=${FW_DIR} O=${UBOOT_DIR}/out/${ARM_A_CORE} &>>"${LOG_FILE}"
+        cp ${UBOOT_DIR}/out/${ARM_A_CORE}/tispl.bin ${OUTDIR}/ &>> ${LOG_FILE}
+        cp ${UBOOT_DIR}/out/${ARM_A_CORE}/u-boot.img ${OUTDIR}/ &>> ${LOG_FILE}
+
+        # restore original env file, if debugging.  Normally, the entire bsp_sources are removed
+        cp board/ti/am64x/am64x.env.orig board/ti/am64x/am64x.env
+        ;;
+    esac
 }
 

--- a/scripts/build_distroiGOS.sh
+++ b/scripts/build_distroiGOS.sh
@@ -54,6 +54,15 @@ bsp_version=$2
     mksquashfs tisdk-debian-${distro}-${bsp_version}-boot tisdk-debian-${distro}-${bsp_version}-boot.squashfs -comp xz -noappend &>>"${LOG_FILE}"
     mv tisdk-debian-${distro}-${bsp_version}-boot.squashfs ${topdir}/images/${build}
 
+# PERLE - squash and save emmc uboot for EVM boards with sdcard, where sdcard is the base and emmc boot is optional
+    EMMCDIR="tisdk-debian-${distro}-${bsp_version}-boot-emmc"
+
+    if [[ -d "$EMMCDIR" ]]; then
+        mksquashfs "$EMMCDIR" "${EMMCDIR}.squashfs" -comp xz -noappend &>>"${LOG_FILE}"
+        mv "${EMMCDIR}.squashfs" "${topdir}/images/${build}/"
+    fi
+
+# PERLE - comment out below for debugging: optee, ti-uboot, etc will build if source is left around
     rm -rf bsp_sources
 
     cd ${topdir}/build/


### PR DESCRIPTION
Fixes to default emmc environment for automating the booting of an emmc squash image, Uboot can now check for and read a EFI/FAT uEnv.txt file for 'uenvcmd=...' command.  This was done as part of building a production emmc image where the uenvcmd includes the loading of a dtb, grub binary and running grub. Bug fixes include override mmcdev to 0, bootpart to 0:2 and loadbootenv to use bootpart.  The stock eval board bootloader environment assumes SD boot using mmcdev 1, etc, so we create 2 sets of uboot files that 'make prod-image' uses the emmc version and 'make sdcard[-squashfs]' uses the original.