### PR TITLE
Transition from a flat EXT4, single partition emmc format to the EFI/grub, EXT4/squashfs/overlayfs format that includes boot cmds in uEnv.txt residing in the EFI partition

### DIFF
--- a/patches/bookworm-am64xx-iolan/ti-u-boot/0001-iolan-configuration.patch
+++ b/patches/bookworm-am64xx-iolan/ti-u-boot/0001-iolan-configuration.patch
@@ -2086,7 +2086,7 @@ new file mode 100755
 index 00000000000..88a34abda49
 --- /dev/null
 +++ b/board/ti/iolan/iolan.env
-@@ -0,0 +1,58 @@
+@@ -0,0 +1,59 @@
 +#include <environment/ti/ti_armv7_common.env>
 +#include <environment/ti/mmc.env>
 +#include <environment/ti/k3_dfu_combined.env>
@@ -2108,8 +2108,9 @@ index 00000000000..88a34abda49
 +
 +boot=mmc
 +mmcdev=0
-+bootpart=0:1
++bootpart=0:2
 +bootdir=/boot
++loadbootenv=fatload mmc ${bootpart} ${loadaddr} ${bootenvfile}
 +rd_spec=-
 +
 +rproc_fw_binaries= 0 /lib/firmware/am64-main-r5f0_0-fw 1 /lib/firmware/am64-main-r5f0_1-fw


### PR DESCRIPTION
Transition from a flat EXT4, single partition emmc format to the EFI/grub, EXT4/squashfs/overlayfs format that includes boot cmds in uEnv.txt residing in the EFI partition.  Allows flexibility in adding commands to the uEnv.txt to implement logic like reading gpio for reset button and emitting a RESET.env file to the EFI partition so grub can boot the factory image or normal, and reading the eeprom and setting up Perle model info in either a file or pass as a kernel cmdline option